### PR TITLE
chore(ci): intentionally downgrade Kotlin DSL version

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.22.0")
+@file:DependsOn("it.krzeminski:github-actions-kotlin-dsl:0.21.0")
 
 import it.krzeminski.githubactions.actions.actions.CheckoutV3
 import it.krzeminski.githubactions.actions.gradle.GradleBuildActionV2


### PR DESCRIPTION
I'd like to test new Renovate Bot's feature, it should be able to
create a PR with bumping to 0.22.0.