### PR TITLE
Add dummy workflow triggered on comments

### DIFF
--- a/.github/workflows/regenerate-yarn-lock.main.kts
+++ b/.github/workflows/regenerate-yarn-lock.main.kts
@@ -1,0 +1,35 @@
+#!/usr/bin/env kotlin
+@file:Repository("https://repo1.maven.org/maven2/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
+
+@file:Repository("https://bindings.krzeminski.it")
+@file:DependsOn("actions:checkout:v6")
+
+import io.github.typesafegithub.workflows.domain.RunnerType
+import io.github.typesafegithub.workflows.domain.triggers.IssueComment
+import io.github.typesafegithub.workflows.dsl.expressions.expr
+import io.github.typesafegithub.workflows.dsl.workflow
+import io.github.typesafegithub.workflows.yaml.CheckoutActionVersionSource
+import io.github.typesafegithub.workflows.yaml.DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG
+
+workflow(
+    name = "Build",
+    on = listOf(
+        IssueComment()
+    ),
+    consistencyCheckJobConfig = DEFAULT_CONSISTENCY_CHECK_JOB_CONFIG.copy(
+        checkoutActionVersion = CheckoutActionVersionSource.InferFromClasspath(),
+    ),
+    sourceFile = __FILE__,
+) {
+    job(
+        id = "regenerate-yarn-lock",
+        runsOn = RunnerType.UbuntuLatest,
+        `if` = expr("!github.event.issue.pull_request")
+    ) {
+        run(
+            name = "Run command",
+            command = "echo ${expr("github.event.issue_comment")}",
+        )
+    }
+}

--- a/.github/workflows/regenerate-yarn-lock.yaml
+++ b/.github/workflows/regenerate-yarn-lock.yaml
@@ -1,0 +1,30 @@
+# This file was generated using Kotlin DSL (.github/workflows/regenerate-yarn-lock.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/typesafegithub/github-workflows-kt
+
+name: 'Build'
+on:
+  issue_comment: {}
+jobs:
+  check_yaml_consistency:
+    name: 'Check YAML consistency'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - id: 'step-0'
+      name: 'Check out'
+      uses: 'actions/checkout@v6'
+    - id: 'step-1'
+      name: 'Execute script'
+      run: 'rm ''.github/workflows/regenerate-yarn-lock.yaml'' && ''.github/workflows/regenerate-yarn-lock.main.kts'''
+    - id: 'step-2'
+      name: 'Consistency check'
+      run: 'git diff --exit-code ''.github/workflows/regenerate-yarn-lock.yaml'''
+  regenerate-yarn-lock:
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    if: '${{ !github.event.issue.pull_request }}'
+    steps:
+    - id: 'step-0'
+      name: 'Run command'
+      run: 'echo ${{ github.event.issue_comment }}'


### PR DESCRIPTION
The end goal is to have a tool that commits a regenerated yarn.lock when we add a specific comment under a PR. This PR is a first iteration.